### PR TITLE
feat: `options.octoherd.{debug,onLogData,onLogMessage}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ By default you authenticate using a token, but you can use any [authentication s
 
 ### Logging
 
-The logging methods `octokit.log.{debug,info,warn,error}()` use [`pino`](https://getpino.io/#/). Log lines are newline delimited JSON ([NDJSON](https://en.wikipedia.org/wiki/JSON_streaming#Line-delimited_JSON)) by default.
+By default, messages are logged with meta data using `console.info`, `console.warn`, and `console.error`. `octokit.log.debug` is a no-op, unless `options.octoherd.debug` is set to `true`.
 
-You can log simple messages
+**Important**: `options.log` is ignored. Setting it has no effect.
+
+You can log simple messages, interpolation is supported.
 
 ```js
 octokit.log.info("Checking repository %s", repository.full_name);
@@ -92,11 +94,28 @@ octokit.log.info({
 });
 ```
 
-You can pass a custom `pino` instance as construction option:
+The way data is logged can be customized using `options.octoherd.onLogMessage` and `options.octoherd.onLogData`.
 
 ```js
 const octokit = new Octokit({
-  logger: pino({ level: "debug" }),
+  octoherd: {
+    onLogData(data) {
+      // e.g. write data as JSON line to debug log file
+      // data always has `.level`, and `.time` properties. `.msg` is set from the log message if set.
+    },
+    onLogMessage(level, message, additionalData) {
+      // level is one of: debug, info, warn, error.
+      // message is the log message
+      // additionalData is any data that was passed as first argument to the log methods. It defaults to {}
+      console.log(
+        `[%s]`,
+        level.toUpperCase(),
+        Object.keys(additionalData).length
+          ? `${message} ${chalk.gray(JSON.stringify(additionalData))}`
+          : message
+      );
+    },
+  },
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -2,24 +2,16 @@ import { Octokit as OctokitCore } from "@octokit/core";
 import { paginateRest } from "@octokit/plugin-paginate-rest";
 import { throttling } from "@octokit/plugin-throttling";
 import { retry } from "@octokit/plugin-retry";
-import pino from "pino";
 
-import { loggerPlugin } from "./octokit-plugins/logger.js";
+import { logger } from "./octokit-plugins/logger.js";
 import { VERSION } from "./version.js";
 
-const logger = pino();
 export const Octokit = OctokitCore.plugin(
-  loggerPlugin,
+  logger,
   paginateRest,
   throttling,
   retry
 ).defaults({
-  log: {
-    debug: logger.debug.bind(logger),
-    info: logger.info.bind(logger),
-    warn: logger.warn.bind(logger),
-    error: logger.error.bind(logger),
-  },
   userAgent: `octoherd-cli/${VERSION}`,
   throttle: {
     onAbuseLimit: (error, options, octokit) => {

--- a/octokit-plugins/logger.js
+++ b/octokit-plugins/logger.js
@@ -1,5 +1,36 @@
-export function loggerPlugin(octokit, options) {
-  if (options.logger) {
-    octokit.log = options.logger;
+import format from "quick-format-unescaped";
+
+function onLogData(obj) {}
+function onLogMessage(level, msg, data) {
+  console[level](msg, data);
+}
+
+function log(level, callbacks, ...args) {
+  const obj = typeof args[0] === "object" ? args.shift() : {};
+  const msg = args.length >= 2 ? format(args.shift(), args) : args[0];
+
+  if (typeof msg !== "undefined") {
+    obj.msg = msg;
   }
+
+  if (obj.msg) {
+    const { msg: message, ...data } = obj;
+    callbacks.onLogMessage(level, message, data);
+  }
+
+  callbacks.onLogData({ ...obj, level, time: Date.now() });
+}
+
+export function logger(octokit, { octoherd = {} }) {
+  const callbacks = {
+    onLogData: octoherd.onLogData || onLogData,
+    onLogMessage: octoherd.onLogMessage || onLogMessage,
+  };
+
+  octokit.log = {
+    debug: octoherd.debug ? log.bind(null, "debug", callbacks) : () => {},
+    info: log.bind(null, "info", callbacks),
+    warn: log.bind(null, "warn", callbacks),
+    error: log.bind(null, "error", callbacks),
+  };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "octokit",
+  "name": "@octoherd/octokit",
   "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
@@ -410,11 +410,6 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
-    },
-    "atomic-sleep": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -871,16 +866,6 @@
         "picomatch": "^2.2.1"
       }
     },
-    "fast-redact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
-      "integrity": "sha512-a/S/Hp6aoIjx7EmugtzLqXmcNsyFszqbt6qQ99BdG61QjBZF6shNis0BYR6TsZOQ1twYc0FN2Xdhwwbv6+KD0w=="
-    },
-    "fast-safe-stringify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
-    },
     "fastq": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.1.tgz",
@@ -926,11 +911,6 @@
       "requires": {
         "semver-regex": "^3.1.2"
       }
-    },
-    "flatstr": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "from2": {
       "version": "2.3.0",
@@ -5365,24 +5345,6 @@
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
-    "pino": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.11.1.tgz",
-      "integrity": "sha512-PoDR/4jCyaP1k2zhuQ4N0NuhaMtei+C9mUHBRRJQujexl/bq3JkeL2OC23ada6Np3zeUMHbO4TGzY2D/rwZX3w==",
-      "requires": {
-        "fast-redact": "^3.0.0",
-        "fast-safe-stringify": "^2.0.7",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^3.1.0",
-        "quick-format-unescaped": "^4.0.1",
-        "sonic-boom": "^1.0.2"
-      }
-    },
-    "pino-std-serializers": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
-    },
     "pkg-conf": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
@@ -5785,15 +5747,6 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
-    },
-    "sonic-boom": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.3.2.tgz",
-      "integrity": "sha512-/B4tAuK2+hIlR94GhhWU1mJHWk5lt0CEuBvG0kvk1qIAzQc4iB1TieMio8DCZxY+Y7tsuzOxSUDOGmaUm3vXMg==",
-      "requires": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
-      }
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@octokit/plugin-paginate-rest": "^2.9.1",
     "@octokit/plugin-retry": "^3.0.7",
     "@octokit/plugin-throttling": "^3.4.1",
-    "pino": "^6.11.1"
+    "quick-format-unescaped": "^4.0.1"
   },
   "devDependencies": {
     "semantic-release": "^17.3.9",

--- a/test.js
+++ b/test.js
@@ -1,7 +1,15 @@
 import { strict as assert } from "assert";
 import { Octokit } from "./index.js";
 
-const octokit = new Octokit();
+const logMessageCalls = [];
+const logDataCalls = [];
+
+const octokit = new Octokit({
+  octoherd: {
+    onLogMessage: (...args) => logMessageCalls.push(args),
+    onLogData: (...args) => logDataCalls.push(args),
+  },
+});
 
 octokit.hook.wrap("request", (request, { url }) => {
   if (url === "/") return { ok: true };
@@ -19,5 +27,40 @@ const issues = await octokit.paginate("GET /repos/{owner}/{repo}/issues", {
 });
 
 assert.equal(issues[0].id, 123);
+
+octokit.log.debug("debug");
+octokit.log.info("info");
+octokit.log.info("info with %s", "interpolation");
+octokit.log.info({ meta: "data" }, "info");
+octokit.log.info({ meta: "data" }, "info with %s", "interpolation");
+
+assert.deepEqual(logMessageCalls, [
+  ["info", "info", {}],
+  ["info", "info with interpolation", {}],
+  ["info", "info", { meta: "data" }],
+  ["info", "info with interpolation", { meta: "data" }],
+]);
+assert.deepEqual(
+  logDataCalls.map(([data]) => [{ ...data, time: 0 }]),
+  [
+    [{ msg: "info", level: "info", time: 0 }],
+    [
+      {
+        msg: "info with interpolation",
+        level: "info",
+        time: 0,
+      },
+    ],
+    [{ meta: "data", msg: "info", level: "info", time: 0 }],
+    [
+      {
+        meta: "data",
+        msg: "info with interpolation",
+        level: "info",
+        time: 0,
+      },
+    ],
+  ]
+);
 
 console.log("All tests passed.");


### PR DESCRIPTION
BREAKING CHANGE: `options.log` is now ignored. Setting it has no longer any effect. Use `options.octoherd.onLogMessage` to customize logging instead