### PR TITLE
feat(typescript): add explicit types for the Octokit export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,22 @@
+// This should not be necssary :( But without the explict type definitions
+// `@octoherd/octokit` exports the Class type instead of the instance type,
+// and using "InstanceType<import('@octoherd/octokit').Octokit>" does not
+// include the types from the plugins (octokit.paginate)
+//
+// The code is based on the generated type definitions from @octokit/rest:
+// https://unpkg.com/browse/@octokit/rest/dist-types/index.d.ts
+import { Octokit as Core } from "@octokit/core";
+export declare const Octokit: (new (...args: any[]) => {
+  [x: string]: any;
+}) & {
+  new (...args: any[]): {
+    [x: string]: any;
+  };
+  plugins: any[];
+} & typeof Core &
+  import("@octokit/core/dist-types/types").Constructor<
+    void & {
+      paginate: import("@octokit/plugin-paginate-rest").PaginateInterface;
+    }
+  >;
+export declare type Octokit = InstanceType<typeof Octokit>;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "description": "Customized Octokit for Octoherd",
   "type": "module",
   "exports": "./index.js",
+  "types": "./index.d.ts",
   "engines": {
     "node": ">12"
   },


### PR DESCRIPTION
This should not be necessary :( But without the explict type definitions `@octoherd/octokit` exports the Class type instead of the instance type, and using `"InstanceType<import('@octoherd/octokit').Octokit>"` does not include the types from the plugins (`octokit.paginate`)

The code is based on the generated type definitions from `@octokit/rest`:
https://unpkg.com/browse/@octokit/rest/dist-types/index.d.ts