### PR TITLE
fix(logger): onLogMessage should concatenate state.context to data

### DIFF
--- a/octokit-plugins/logger.js
+++ b/octokit-plugins/logger.js
@@ -25,7 +25,7 @@ function log(state, level, ...args) {
 
   if (obj.msg && (level !== "debug" || state.options.debug)) {
     const { msg: message, ...data } = obj;
-    state.onLogMessage(level, message, data);
+    state.onLogMessage(level, message, { ...state.context, ...data });
   }
 
   state.onLogData({ ...state.context, ...obj, level, time: Date.now() });


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
`onLogMessage()` should concatenate state.context to data as it's done for `onLogData()`

https://github.com/octoherd/octokit/blob/7b247dba80c71769b31a14de83fa90499d18f422/octokit-plugins/logger.js#L31

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
After applying this fix to `@octoherd/cli`, the context logs were not appearing because of this issue

Fix #6 

## 📊 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running locally the changes with an a local octoherd script

## 📸 Screenshots:
`{a: 1}` is the object passed from octoher's script
### Before
![image](https://user-images.githubusercontent.com/2574275/110240092-83c58700-7f4a-11eb-8497-16b8260f52b7.png)

### After
![image](https://user-images.githubusercontent.com/2574275/110240116-a8216380-7f4a-11eb-846f-33a17b4da3b7.png)

here we pass only `owner.login` to show the concatenation with `{a: 1}` works
![image](https://user-images.githubusercontent.com/2574275/110240075-77d9c500-7f4a-11eb-87ad-62f00964a69c.png)
