### PR TITLE
fix: upgrade `@octokit/core`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ export declare const Octokit: (new (...args: any[]) => {
   };
   plugins: any[];
 } & typeof Core &
-  import("@octokit/core/dist-types/types").Constructor<
+  import("@octokit/core/types").Constructor<
     void & {
       paginate: import("@octokit/plugin-paginate-rest").PaginateInterface;
     } & {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.0.0-development",
       "license": "ISC",
       "dependencies": {
-        "@octokit/core": "^6.0.0",
+        "@octokit/core": "^6.1.2",
         "@octokit/plugin-paginate-rest": "^11.0.0",
         "@octokit/plugin-retry": "^7.0.0",
         "@octokit/plugin-throttling": "^9.0.0",
         "quick-format-unescaped": "^4.0.1"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -28,9 +28,9 @@
       }
     },
     "node_modules/@octokit/core": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.1.tgz",
-      "integrity": "sha512-uVypPdnZV7YoEa69Ky2kTSw3neFLGT0PZ54OwUMDph7w6TmhF0ZnoVcvb/kYnjDHCFo2mfoeRDYifLKhLNasUg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
+      "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "exports": "./index.js",
   "types": "./index.d.ts",
   "engines": {
-    "node": ">= 14"
+    "node": ">= 18"
   },
   "scripts": {
     "test": "node test.js"
@@ -22,7 +22,7 @@
   "license": "ISC",
   "repository": "github:octoherd/octokit",
   "dependencies": {
-    "@octokit/core": "^6.0.0",
+    "@octokit/core": "^6.1.2",
     "@octokit/plugin-paginate-rest": "^11.0.0",
     "@octokit/plugin-retry": "^7.0.0",
     "@octokit/plugin-throttling": "^9.0.0",


### PR DESCRIPTION
Fixes #81

It seems that `@octokit/core` was upgraded and the engines field in this package wasn't

BREAKING CHANGE: require NodeJS >= 18